### PR TITLE
Fix pokedex evo page bug for Tyrogue

### DIFF
--- a/engine/pokedex/pokedex_evolution_page.asm
+++ b/engine/pokedex/pokedex_evolution_page.asm
@@ -432,9 +432,10 @@ EVO_stats:
 	cp ATK_EQ_DEF
 	jr z, .done
 	ld de, .atk_gt_def_text
-	cp ATK_LT_DEF
+	cp ATK_GT_DEF
 	jr z, .done
 	ld de, .atk_lt_def_text
+	cp ATK_LT_DEF
 .done
 	call EVO_inchlcoord
 	call PlaceString

--- a/maps/ElmsLab.asm
+++ b/maps/ElmsLab.asm
@@ -160,8 +160,8 @@ CyndaquilPokeBallScript:
 	iftrue LookAtElmPokeBallScript
 	turnobject ELMSLAB_ELM, DOWN
 	refreshscreen
-	pokepic CYNDAQUIL
-	cry CYNDAQUIL
+	pokepic TYROGUE
+	cry TYROGUE
 	waitbutton
 	closepokepic
 	opentext
@@ -173,12 +173,13 @@ CyndaquilPokeBallScript:
 	writetext ChoseStarterText
 	promptbutton
 	waitsfx
-	getmonname STRING_BUFFER_3, CYNDAQUIL
+	setflag ENGINE_POKEDEX
+	getmonname STRING_BUFFER_3, TYROGUE
 	writetext ReceivedStarterText
 	playsound SFX_CAUGHT_MON
 	waitsfx
 	promptbutton
-	givepoke CYNDAQUIL, 5, BERRY
+	givepoke TYROGUE, 5, BERRY
 	closetext
 	readvar VAR_FACING
 	ifequal RIGHT, ElmDirectionsScript

--- a/maps/ElmsLab.asm
+++ b/maps/ElmsLab.asm
@@ -160,8 +160,8 @@ CyndaquilPokeBallScript:
 	iftrue LookAtElmPokeBallScript
 	turnobject ELMSLAB_ELM, DOWN
 	refreshscreen
-	pokepic TYROGUE
-	cry TYROGUE
+	pokepic CYNDAQUIL
+	cry CYNDAQUIL
 	waitbutton
 	closepokepic
 	opentext
@@ -173,13 +173,12 @@ CyndaquilPokeBallScript:
 	writetext ChoseStarterText
 	promptbutton
 	waitsfx
-	setflag ENGINE_POKEDEX
-	getmonname STRING_BUFFER_3, TYROGUE
+	getmonname STRING_BUFFER_3, CYNDAQUIL
 	writetext ReceivedStarterText
 	playsound SFX_CAUGHT_MON
 	waitsfx
 	promptbutton
-	givepoke TYROGUE, 5, BERRY
+	givepoke CYNDAQUIL, 5, BERRY
 	closetext
 	readvar VAR_FACING
 	ifequal RIGHT, ElmDirectionsScript


### PR DESCRIPTION
This user found a [bug](https://www.reddit.com/r/PokemonLegacy/comments/1e651uu/dex_complete_but_i_found_a_problem/) with Tyrogue's evo page where the evo conditions for Hitmonchan and Hitmonlee are reversed.

It annoyed me, so I tried to fix it for my fork and came up with this.
I don't know if this is the proper fix, but it seems to fix the immediate problem.

I've tested this by changing one of the starters to Tyrogue and unlocking the dex right away for easier reproduction.
I left the testing commits in here in case you wanna check/make further changes.