### PR TITLE
tweak victory road rival dialogue for (imo) better flow and characterisiation

### DIFF
--- a/maps/IndigoPlateauPokecenter1F.asm
+++ b/maps/IndigoPlateauPokecenter1F.asm
@@ -239,11 +239,9 @@ PlateauRivalText1:
 	para "That's not going"
 	line "to happen."
 
-	para "My super-well-"
-	line "trained #MON"
-
-	para "are going to pound"
-	line "you."
+	para "Me and my team"
+	line "are going to pound"
+	cont "you."
 
 	para "<PLAYER>!"
 	line "I challenge you!"

--- a/maps/MountMoon.asm
+++ b/maps/MountMoon.asm
@@ -103,15 +103,18 @@ MountMoonSilverTextBefore:
 	para "It's been a while,"
 	line "<PLAYER>."
 
-	para "…Since I lost to"
-	line "you, I thought"
+	para "I've thought more"
+	line "about what I was"
 
-	para "about what I was"
-	line "lacking with my"
-	cont "#MON…"
+	para "lacking with my"
+	line "#MON…"
 
 	para "And we came up"
 	line "with an answer."
+
+	para "Since we lost to"
+	line "you, we've grown"
+	cont "stronger together."
 
 	para "<PLAYER>, now we'll"
 	line "show you!"

--- a/maps/MountMoon.asm
+++ b/maps/MountMoon.asm
@@ -152,11 +152,15 @@ MountMoonSilverTextAfter:
 
 	para "…Listen, <PLAYER>."
 
-	para "One of these days"
-	line "I'm going to prove"
+	para "What you possess,"
+	line "and what I've"
+	cont "lacked…"
 
-	para "how good I am by"
-	line "beating you."
+	para "I understand now."
+
+	para "One of these days,"
+	line "I'm going to prove"
+	cont "that to you."
 	done
 
 MountMoonSilverTextLoss:

--- a/maps/Route26.asm
+++ b/maps/Route26.asm
@@ -355,11 +355,17 @@ CooltrainerfJoyceAfterBattleText:
 	done
 
 CooltrainerfBeth1SeenText:
-	text "I lost to a train-"
-	line "er named <RIVAL>."
+	text "I once lost to a"
+	line "trainer named"
+	cont "<RIVAL>."
+
+	para "I think I saw him"
+	line "head into VICTORY"
+	cont "ROAD just now."
 
 	para "He was really"
-	line "strong, but…"
+	line "strong, but when"
+	cont "I battled him…"
 
 	para "It was as if he"
 	line "absolutely had to"
@@ -378,6 +384,10 @@ CooltrainerfBethAfterText:
 	text "#MON are in-"
 	line "valuable, lifelong"
 	cont "partners."
+
+	para "I hope that train-"
+	line "er understands"
+	cont "some day."
 	done
 
 PsychicRichardSeenText:

--- a/maps/VictoryRoad.asm
+++ b/maps/VictoryRoad.asm
@@ -271,7 +271,7 @@ VictoryRoadRivalDefeatText:
 	done
 
 VictoryRoadRivalAfterText:
-	text "My #MON"
+	text "My TYRANITAR"
 	line "evolved early…"
 
 	para "Perhaps it was"

--- a/maps/VictoryRoad.asm
+++ b/maps/VictoryRoad.asm
@@ -59,6 +59,7 @@ VictoryRoadRivalNext:
 	showemote EMOTE_SHOCK, VICTORYROAD_SILVER, 15
 	special FadeOutMusic
 	pause 15
+	opentext
 	writetext VictoryRoadRivalEvolveText
 	waitbutton
 	closetext

--- a/maps/VictoryRoad.asm
+++ b/maps/VictoryRoad.asm
@@ -254,7 +254,7 @@ VictoryRoadRivalBeforeText:
 	done
 	
 VictoryRoadRivalEvolveText:
-	para ".....What?"
+	text ".....What?"
 	line "PUPITAR?"
 	
 	para "............"
@@ -264,12 +264,12 @@ VictoryRoadRivalEvolveText:
 	line "It's evolving?!"
 
 VictoryRoadRivalDefeatText:
-	para "We gave it every-"
+	text "We gave it every-"
 	line "thing we had…"
 	done
 
 VictoryRoadRivalAfterText:
-	para "My #MON"
+	text "My #MON"
 	line "evolved early…"
 
 	para "Perhaps it was"
@@ -315,7 +315,7 @@ VictoryRoadRivalAfterText:
 	done
 
 VictoryRoadRivalVictoryText:
-	para "When it comes down"
+	text "When it comes down"
 	line "to it, nothing can"
 	cont "beat friendhship."
 

--- a/maps/VictoryRoad.asm
+++ b/maps/VictoryRoad.asm
@@ -262,6 +262,7 @@ VictoryRoadRivalEvolveText:
 	
 	para "My PUPITAR…"
 	line "It's evolving?!"
+	done
 
 VictoryRoadRivalDefeatText:
 	text "We gave it every-"

--- a/maps/VictoryRoad.asm
+++ b/maps/VictoryRoad.asm
@@ -276,16 +276,21 @@ VictoryRoadRivalAfterText:
 	line "the ROCKETs"
 	cont "radio signal?"
 
-	para "Or some say that"
-	line "through love,"
+	para "Or the dragon"
+	line "master…"
 	
-	para "the dragon"
-	line "master was able"
-	
-	para "to do such a"
-	line "thing too…"
+	para "It's said the bond"
+	line "between him and"
 
-	para "It matters not."
+	para "his #MON"
+	line "is so strong,"
+	
+	para "he was once able"
+	line "to do the same"
+	cont "thing too."
+
+	para "But it doesn't"
+	line "matter."
 
 	para "I can't give up"
 	line "on becoming the"

--- a/maps/VictoryRoad.asm
+++ b/maps/VictoryRoad.asm
@@ -289,9 +289,9 @@ VictoryRoadRivalAfterText:
 	
 	para "he was once able"
 	line "to do the same"
-	cont "thing."
+	cont "thing…"
 
-	para "But it doesn't"
+	para "…But that doesn't"
 	line "matter."
 
 	para "I can't give up"

--- a/maps/VictoryRoad.asm
+++ b/maps/VictoryRoad.asm
@@ -242,12 +242,12 @@ VictoryRoadRivalBeforeText:
 	para "and I have treated"
 	line "them like pawns."
 	
-	para "But I promise!"
+	para "But I promise now,"
 	line "I will care for"
-	cont "all of you."
+	cont "all of them!"
 	
-	para "Together, we"
-	line "will become"
+	para "Because together,"
+	line "we will become"
 	cont "unstoppable."
 
 	para "<PLAYER>!"

--- a/maps/VictoryRoad.asm
+++ b/maps/VictoryRoad.asm
@@ -289,7 +289,7 @@ VictoryRoadRivalAfterText:
 	
 	para "he was once able"
 	line "to do the same"
-	cont "thing too."
+	cont "thing."
 
 	para "But it doesn't"
 	line "matter."

--- a/maps/VictoryRoad.asm
+++ b/maps/VictoryRoad.asm
@@ -56,6 +56,12 @@ VictoryRoadRivalNext:
 	writetext VictoryRoadRivalBeforeText
 	waitbutton
 	closetext
+	showemote EMOTE_SHOCK, VICTORYROAD_SILVER, 15
+	special FadeOutMusic
+	pause 15
+	writetext VictoryRoadRivalEvolveText
+	waitbutton
+	closetext
 	setevent EVENT_RIVAL_VICTORY_ROAD
 	checkevent EVENT_GOT_TOTODILE_FROM_ELM
 	iftrue .GotTotodile
@@ -203,26 +209,29 @@ VictoryRoadRivalBeforeText:
 
 	para "You're so much"
 	line "weaker than I am."
+
+	para "Do you know"
+	line "why that is?"
 	
-	para "Even so, I've"
-	line "realized there"
+	para "Because I've"
+	line "realized there is"
 
-	para "is more to it"
-	line "than power."
-	
-	para "I've begun to"
-	line "understand what"
+	para "more to #MON"
+	line "than raw power."
 
-	para "that dragon master"
-	line "said to me…"
+	para "That dragon master"
+	line "was right…"
 
-	para "Love, friendship.."
-	line "it's what the"
-	cont "elders in the"
+	para "True strength can"
+	line "only come through"
+	cont "friendship."
+
+	para "It's what the"
+	line "elders in the"
 	
 	para "DRAGON'S DEN"
 	line "said too."
-	
+
 	para "I need to care"
 	line "for my team."
 	
@@ -239,91 +248,68 @@ VictoryRoadRivalBeforeText:
 	para "Together, we"
 	line "will become"
 	cont "unstoppable."
+
+	para "<PLAYER>!"
+	line "I challenge you…"
+	done
 	
-	para "What? PUPITAR"
-	line "is evolving!"
+VictoryRoadRivalEvolveText:
+	para ".....What?"
+	line "PUPITAR?"
 	
 	para "............"
 	line "............"
 	
-	para "Congratulations!"
-	line "Your PUPITAR"
+	para "My PUPITAR…"
+	line "It's evolving?!"
 
-	para "evolved into"
-	line "TYRANITAR?"
-	
-	para ".....What?"
-	line "TYRANITAR?"
-	
-	para "But......."
-	line "level....."
-	
-	para "Ah no, I see."
-	line "I've heard of"
-	
-	para "rare instances"
-	line "of early evol-"
-	cont "ution."
-	
-	para "Some say that"
+VictoryRoadRivalDefeatText:
+	para "We gave it every-"
+	line "thing we had…"
+	done
+
+VictoryRoadRivalAfterText:
+	para "My #MON"
+	line "evolved early…"
+
+	para "Perhaps it was"
+	line "the ROCKETs"
+	cont "radio signal?"
+
+	para "Or some say that"
 	line "through love,"
 	
 	para "the dragon"
 	line "master was able"
 	
 	para "to do such a"
-	line "thing too."
-	
-	para "Perhaps it was"
-	line "the ROCKETs"
-	cont "radio signal."
-	
+	line "thing too…"
+
 	para "It matters not."
-	line "Let's battle."
-	
-	para "My friends will"
-	line "beat you and then"
-	cont "the ELITE FOUR."
 
-	para "<PLAYER>!"
-	line "I challenge you!"
-	done
-
-VictoryRoadRivalDefeatText:
-	text "…I couldn't win…"
-
-	para "I gave it every-"
-	line "thing I had…"
-
-	para "What you possess,"
-	line "and what I lack…"
-	done
-
-VictoryRoadRivalAfterText:
-	text "…I haven't given up"
+	para "I can't give up"
 	line "on becoming the"
 	cont "greatest trainer…"
 
-	para "But that's okay,"
-	line "I will one day"
+	para "Not now."
+	line "Not with this team."
 
-	para "return and"
-	line "become stronger."
+	para "<PLAYER>!"
+	line "We will return"
+	cont "even stronger."
 
-	para "When I do, I will"
+	para "When we do, we'll"
 	line "challenge you."
 
-	para "And I'll beat you"
-	line "down with all my"
+	para "And we'll beat you"
+	line "down with all our"
 	cont "power."
 
-	para "Come on guys!"
-	line "let's go!"
+	para "Come on, guys."
+	line "Let's go."
 	done
 
 VictoryRoadRivalVictoryText:
-	text "What power!"
-
 	para "When it comes down"
 	line "to it, nothing can"
 	cont "beat friendhship."

--- a/maps/VictoryRoad.asm
+++ b/maps/VictoryRoad.asm
@@ -285,7 +285,7 @@ VictoryRoadRivalAfterText:
 	line "between him and"
 
 	para "his #MON"
-	line "is so strong,"
+	line "was so strong,"
 	
 	para "he was once able"
 	line "to do the same"


### PR DESCRIPTION
I've personally thought that the rival dialogue in victory road could use some improvement for better and more consistent  characterisation, and that it would be better to have the explanation for the early evolution after the battle instead. i've tried to edit the script so that just before the battle the music fades out, a shock bubble appears, rival says "my pupitar is evolving!" then battle starts (as I think that flows better). haven't tested it as I don't have a save file for that part of the game to hand but hopefully it works and you all feel it's a good change to how the scene plays out.