### PR TITLE
Fix Archer id/class mixup

### DIFF
--- a/data/trainers/dvs.asm
+++ b/data/trainers/dvs.asm
@@ -70,7 +70,7 @@ TrainerClassDVs:
 	dn  7, 14, 10,  8 ; GRUNTF
 	dn  9,  8,  8,  8 ; MYSTICALMAN
 	dn 12, 12, 12, 12 ; BOSS
-	dn 11, 11, 11, 11 ; ARCHER
+	dn 11, 11, 11, 11 ; ROCKET_LEADER
 	dn 13, 12, 13, 13 ; PKMNTRAINERF
 
 	assert_table_length NUM_TRAINER_CLASSES

--- a/data/trainers/gendered_trainers.asm
+++ b/data/trainers/gendered_trainers.asm
@@ -27,7 +27,7 @@ MaleTrainers:
 	db BIKER
 	db SCIENTIST
 	db BOSS
-	db ARCHER
+	db ROCKET_LEADER
 .End
 
 FemaleTrainers:

--- a/data/trainers/genders.asm
+++ b/data/trainers/genders.asm
@@ -71,6 +71,6 @@ BTTrainerClassGenders:
 	db FEMALE ; GRUNTF
 	db MALE   ; MYSTICALMAN
 	db MALE   ; BOSS
-	db MALE   ; ARCHER
+	db MALE   ; ROCKET_LEADER
 	db FEMALE ; PKMNTRAINERF
 	assert_table_length NUM_TRAINER_CLASSES


### PR DESCRIPTION
With the previous code, the literal value `1` was added to the `MaleTrainers`, instead of `$45`. This was because it was adding the trainer **id**, instead of the trainer **class**.

Note that all other constant in the lists are the trainer _class_, not the _id_ of an individual trainer.