### PR TITLE
Use constants for all trainer parties

### DIFF
--- a/constants/trainer_constants.asm
+++ b/constants/trainer_constants.asm
@@ -30,27 +30,41 @@ NUM_NONTRAINER_PHONECONTACTS EQU const_value - 1
 KRIS EQU __trainer_class__
 	trainerclass FALKNER ; 1
 	const FALKNER1
+	const FALKNER2
 
 	trainerclass WHITNEY ; 2
 	const WHITNEY1
+	const WHITNEY2
 
 	trainerclass BUGSY ; 3
 	const BUGSY1
+	const BUGSY2
 
 	trainerclass MORTY ; 4
 	const MORTY1
+	const MORTY2
 
 	trainerclass PRYCE ; 5
 	const PRYCE1
+	const PRYCE2
+	const PRYCE3
+	const PRYCE4
 
 	trainerclass JASMINE ; 6
 	const JASMINE1
+	const JASMINE2
+	const JASMINE3
+	const JASMINE4
 
 	trainerclass CHUCK ; 7
 	const CHUCK1
+	const CHUCK2
+	const CHUCK3
+	const CHUCK4
 
 	trainerclass CLAIR ; 8
 	const CLAIR1
+	const CLAIR2
 
 	trainerclass RIVAL1 ; 9
 	const RIVAL1_1_CHIKORITA
@@ -73,6 +87,7 @@ KRIS EQU __trainer_class__
 
 	trainerclass WILL ; b
 	const WILL1
+	const WILL2
 
 	trainerclass CAL ; c
 	const CAL1 ; unused
@@ -82,15 +97,19 @@ KRIS EQU __trainer_class__
 
 	trainerclass BRUNO ; d
 	const BRUNO1
+	const BRUNO2
 
 	trainerclass KAREN ; e
 	const KAREN1
+	const KAREN2
 
 	trainerclass KOGA ; f
 	const KOGA1
+	const KOGA2
 
 	trainerclass CHAMPION ; 10
 	const LANCE
+	const LANCE2
 
 	trainerclass BROCK ; 11
 	const BROCK1
@@ -686,9 +705,11 @@ KRIS EQU __trainer_class__
 
 	trainerclass RED ; 3f
 	const RED1
+	const RED2
 
 	trainerclass BLUE ; 40
 	const BLUE1
+	const BLUE2
 
 	trainerclass OFFICER ; 41
 	const KEITH
@@ -708,7 +729,8 @@ KRIS EQU __trainer_class__
 	const GIOVANNI
 
 	trainerclass ROCKET_LEADER
-	const ARCHER
+	const ARCHER1
+	const ARCHER2
 
 	trainerclass PKMNTRAINERF
 	const WEEBRA

--- a/data/trainers/gendered_trainers.asm
+++ b/data/trainers/gendered_trainers.asm
@@ -27,7 +27,7 @@ MaleTrainers:
 	db BIKER
 	db SCIENTIST
 	db BOSS
-	db ARCHER
+	db ARCHER1
 .End
 
 FemaleTrainers:

--- a/maps/AzaleaGym.asm
+++ b/maps/AzaleaGym.asm
@@ -74,7 +74,7 @@ AzaleaGymBugsyScript:
 .BugsyRematch:
 	special HealParty
 	winlosstext Bugsy_RematchDefeatText, 0
-	loadtrainer BUGSY, 2
+	loadtrainer BUGSY, BUGSY2
 	checkflag ENGINE_HARD_MODE
 	iffalse .normalmode_2
 	loadvar VAR_BATTLETYPE, BATTLETYPE_SETNOITEMS

--- a/maps/BlackthornGym1F.asm
+++ b/maps/BlackthornGym1F.asm
@@ -105,7 +105,7 @@ BlackthornGymClairScript:
 .ClairRematch:
 	special HealParty
 	winlosstext Clair_RematchDefeatText, 0
-	loadtrainer CLAIR, 2
+	loadtrainer CLAIR, CLAIR2
 	checkflag ENGINE_HARD_MODE
 	iffalse .normalmode_2
 	loadvar VAR_BATTLETYPE, BATTLETYPE_SETNOITEMS

--- a/maps/BrunosRoom.asm
+++ b/maps/BrunosRoom.asm
@@ -60,7 +60,7 @@ BrunoScript_Battle:
 	loadtrainer BRUNO, BRUNO1
 	sjump .LoadtrainerEnd
 .Rematch:
-	loadtrainer BRUNO, 2
+	loadtrainer BRUNO, BRUNO2
 .LoadtrainerEnd:
 	checkflag ENGINE_HARD_MODE
 	iffalse .normalmode_2

--- a/maps/CianwoodGym.asm
+++ b/maps/CianwoodGym.asm
@@ -47,10 +47,10 @@ CianwoodGymChuckScript:
 	loadtrainer CHUCK, CHUCK1
 	sjump .CianwoodGymChuckScriptEnd
 .SixBadges:
-	loadtrainer CHUCK, 2
+	loadtrainer CHUCK, CHUCK2
 	sjump .CianwoodGymChuckScriptEnd
 .SevenBadges:
-	loadtrainer CHUCK, 3
+	loadtrainer CHUCK, CHUCK3
 	sjump .CianwoodGymChuckScriptEnd
 .CianwoodGymChuckScriptEnd:
 	checkflag ENGINE_HARD_MODE
@@ -121,7 +121,7 @@ CianwoodGymChuckScript:
 .ChuckRematch:
 	special HealParty
 	winlosstext Chuck_RematchDefeatText, 0
-	loadtrainer CHUCK, 4
+	loadtrainer CHUCK, CHUCK4
 	checkflag ENGINE_HARD_MODE
 	iffalse .normalmode_4
 	loadvar VAR_BATTLETYPE, BATTLETYPE_SETNOITEMS

--- a/maps/EcruteakGym.asm
+++ b/maps/EcruteakGym.asm
@@ -86,7 +86,7 @@ EcruteakGymMortyScript:
 .MortyRematch:
 	special HealParty
 	winlosstext Morty_RematchDefeatText, 0
-	loadtrainer MORTY, 2
+	loadtrainer MORTY, MORTY2
 	checkflag ENGINE_HARD_MODE
 	iffalse .normalmode_2
 	loadvar VAR_BATTLETYPE, BATTLETYPE_SETNOITEMS

--- a/maps/GoldenrodGym.asm
+++ b/maps/GoldenrodGym.asm
@@ -97,7 +97,7 @@ GoldenrodGymWhitneyScript:
 .WhitneyRematch:
 	special HealParty
 	winlosstext Whitney_RematchDefeatText, 0
-	loadtrainer WHITNEY, 2
+	loadtrainer WHITNEY, WHITNEY2
 	checkflag ENGINE_HARD_MODE
 	iffalse .normalmode_2
 	loadvar VAR_BATTLETYPE, BATTLETYPE_SETNOITEMS

--- a/maps/KarensRoom.asm
+++ b/maps/KarensRoom.asm
@@ -60,7 +60,7 @@ KarenScript_Battle:
 	loadtrainer KAREN, KAREN1
 	sjump .LoadtrainerEnd
 .Rematch:
-	loadtrainer KAREN, 2
+	loadtrainer KAREN, KAREN2
 .LoadtrainerEnd:
 	checkflag ENGINE_HARD_MODE
 	iffalse .normalmode_2

--- a/maps/KogasRoom.asm
+++ b/maps/KogasRoom.asm
@@ -60,7 +60,7 @@ KogaScript_Battle:
 	loadtrainer KOGA, KOGA1
 	sjump .LoadtrainerEnd
 .Rematch:
-	loadtrainer KOGA, 2
+	loadtrainer KOGA, KOGA2
 .LoadtrainerEnd:
 	checkflag ENGINE_HARD_MODE
 	iffalse .normalmode_2

--- a/maps/LancesRoom.asm
+++ b/maps/LancesRoom.asm
@@ -70,7 +70,7 @@ LancesRoomLanceScript:
 	loadtrainer CHAMPION, LANCE
 	sjump .LoadtrainerEnd
 .Rematch:
-	loadtrainer CHAMPION, 2
+	loadtrainer CHAMPION, LANCE2
 .LoadtrainerEnd:
 	checkflag ENGINE_HARD_MODE
 	iffalse .normalmode_2

--- a/maps/MahoganyGym.asm
+++ b/maps/MahoganyGym.asm
@@ -30,10 +30,10 @@ MahoganyGymPryceScript:
 	loadtrainer PRYCE, PRYCE1
 	sjump .MahoganyGymPryceScriptEnd
 .SixBadges:
-	loadtrainer PRYCE, 2
+	loadtrainer PRYCE, PRYCE2
 	sjump .MahoganyGymPryceScriptEnd
 .SevenBadges:
-	loadtrainer PRYCE, 3
+	loadtrainer PRYCE, PRYCE3
 	sjump .MahoganyGymPryceScriptEnd
 .MahoganyGymPryceScriptEnd:
 	checkflag ENGINE_HARD_MODE
@@ -105,7 +105,7 @@ PryceScript_Defeat:
 .PryceRematch:
 	special HealParty
 	winlosstext Pryce_RematchDefeatText, 0
-	loadtrainer PRYCE, 4
+	loadtrainer PRYCE, PRYCE4
 	checkflag ENGINE_HARD_MODE
 	iffalse .normalmode_4
 	loadvar VAR_BATTLETYPE, BATTLETYPE_SETNOITEMS

--- a/maps/OlivineGym.asm
+++ b/maps/OlivineGym.asm
@@ -25,10 +25,10 @@ OlivineGymJasmineScript:
 	loadtrainer JASMINE, JASMINE1
 	sjump .OlivineGymJasmineScriptEnd
 .SixBadges:
-	loadtrainer JASMINE, 2
+	loadtrainer JASMINE, JASMINE2
 	sjump .OlivineGymJasmineScriptEnd
 .SevenBadges:
-	loadtrainer JASMINE, 3
+	loadtrainer JASMINE, JASMINE3
 	sjump .OlivineGymJasmineScriptEnd
 .OlivineGymJasmineScriptEnd
 	checkflag ENGINE_HARD_MODE
@@ -95,7 +95,7 @@ OlivineGymJasmineScript:
 .JasmineRematch:
 	special HealParty
 	winlosstext Jasmine_RematchDefeatText, 0
-	loadtrainer JASMINE, 4
+	loadtrainer JASMINE, JASMINE4
 	checkflag ENGINE_HARD_MODE
 	iffalse .normalmode_4
 	loadvar VAR_BATTLETYPE, BATTLETYPE_SETNOITEMS

--- a/maps/RadioTower5F.asm
+++ b/maps/RadioTower5F.asm
@@ -91,7 +91,7 @@ RadioTower5FRocketBossScene:
 	closetext
 	winlosstext RadioTower5FRocketBossWinText, 0
 	setlasttalked RADIOTOWER5F_ROCKET
-	loadtrainer ROCKET_LEADER, 1
+	loadtrainer ROCKET_LEADER, ARCHER1
 	checkflag ENGINE_HARD_MODE
 	iffalse .normalmode_1
 	loadvar VAR_BATTLETYPE, BATTLETYPE_SETNOITEMS

--- a/maps/SilverCaveRoom3.asm
+++ b/maps/SilverCaveRoom3.asm
@@ -28,7 +28,7 @@ Red:
 	loadtrainer RED, RED1
 	sjump .EndLoadTrainerRed
 .rematchteam
-	loadtrainer RED, 2
+	loadtrainer RED, RED2
 .EndLoadTrainerRed
 	checkflag ENGINE_HARD_MODE
 	iffalse .normalmode_2

--- a/maps/TeamRocketBaseB3F.asm
+++ b/maps/TeamRocketBaseB3F.asm
@@ -102,7 +102,7 @@ RocketBaseBoss:
 	applymovement TEAMROCKETBASEB3F_ROCKET1, RocketBaseBossApproachesPlayerMovement
 	winlosstext ExecutiveM4BeatenText, 0
 	setlasttalked TEAMROCKETBASEB3F_ROCKET1
-	loadtrainer ROCKET_LEADER, 2
+	loadtrainer ROCKET_LEADER, ARCHER2
 	checkflag ENGINE_HARD_MODE
 	iffalse .normalmode_2
 	loadvar VAR_BATTLETYPE, BATTLETYPE_SETNOITEMS

--- a/maps/WillsRoom.asm
+++ b/maps/WillsRoom.asm
@@ -60,7 +60,7 @@ WillScript_Battle:
 	loadtrainer WILL, WILL1
 	sjump .LoadtrainerEnd
 .Rematch:
-	loadtrainer WILL, 2
+	loadtrainer WILL, WILL2
 .LoadtrainerEnd:
 	checkflag ENGINE_HARD_MODE
 	iffalse .normalmode_2


### PR DESCRIPTION
This change introduces constants for the new parties added in the Legacy part, which makes the number of parties (in `data/trainers/parties.asm`) match up exactly with the number of constants (in `constants/trainer_constants.asm`).

The built `gbc` file still has the exact same SHA1 sum: `fc10573e5b05c5ff8bbe460f3081f2cadaa20658`

The motivation behind this is to make the data easier to programmatically extract, for use in e.g.
https://github.com/LinusU/crystal-legacy-pokedex (https://linusu.github.io/crystal-legacy-pokedex)
https://github.com/LinusU/rustic-crystal

note that this PR will conflict with #33, happy to rebase either one after the other is merged!