### PR TITLE
ci: add ROM build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,29 @@
+name: Build
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential bison libpng-dev pkg-config
+
+      - name: Build and install rgbds 0.5.2
+        run: |
+          git clone --depth 1 --branch v0.5.2 https://github.com/gbdev/rgbds /tmp/rgbds
+          make -C /tmp/rgbds -j"$(nproc)"
+          sudo make -C /tmp/rgbds install
+
+      - name: Build pokecrystal.gbc
+        run: make
+
+      - name: Build pokecrystal11.gbc
+        run: make crystal11

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ gfx/pokemon/*/frames.asm
 *.gb
 *.patch
 
+# local build artifacts (ROMs, saves, patches kept out of the repo)
+/builds/
+
 # rgbds extras
 *.map
 *.sym

--- a/Makefile
+++ b/Makefile
@@ -151,12 +151,12 @@ $(foreach obj, $(pokecrystal11_vc_obj), $(eval $(call DEP,$(obj),$(obj:11_vc.o=.
 endif
 
 
-pokecrystal_opt         = -Cjv -t PM_CRYSTAL -i BYTE -n 0 -k 01 -l 0x33 -m 0x10 -r 3 -p 0
-pokecrystal11_opt       = -Cjv -t PM_CRYSTAL -i BYTE -n 1 -k 01 -l 0x33 -m 0x10 -r 3 -p 0
-pokecrystal_au_opt      = -Cjv -t PM_CRYSTAL -i BYTU -n 0 -k 01 -l 0x33 -m 0x10 -r 3 -p 0
-pokecrystal_debug_opt   = -Cjv -t PM_CRYSTAL -i BYTE -n 0 -k 01 -l 0x33 -m 0x10 -r 3 -p 0
-pokecrystal11_debug_opt = -Cjv -t PM_CRYSTAL -i BYTE -n 1 -k 01 -l 0x33 -m 0x10 -r 3 -p 0
-pokecrystal11_vc_opt    = -Cjv -t PM_CRYSTAL -i BYTE -n 1 -k 01 -l 0x33 -m 0x10 -r 3 -p 0
+pokecrystal_opt         = -Cjv -t PM_CRYSTAL -i BYTE -n 0 -k 01 -l 0x33 -m 0x1b -r 3 -p 0
+pokecrystal11_opt       = -Cjv -t PM_CRYSTAL -i BYTE -n 1 -k 01 -l 0x33 -m 0x1b -r 3 -p 0
+pokecrystal_au_opt      = -Cjv -t PM_CRYSTAL -i BYTU -n 0 -k 01 -l 0x33 -m 0x1b -r 3 -p 0
+pokecrystal_debug_opt   = -Cjv -t PM_CRYSTAL -i BYTE -n 0 -k 01 -l 0x33 -m 0x1b -r 3 -p 0
+pokecrystal11_debug_opt = -Cjv -t PM_CRYSTAL -i BYTE -n 1 -k 01 -l 0x33 -m 0x1b -r 3 -p 0
+pokecrystal11_vc_opt    = -Cjv -t PM_CRYSTAL -i BYTE -n 1 -k 01 -l 0x33 -m 0x1b -r 3 -p 0
 
 pokecrystal_base         = us
 pokecrystal11_base       = us

--- a/README.md
+++ b/README.md
@@ -1,4 +1,17 @@
-# Pokémon Crystal Legacy
+# Crystal Legacy Timeless
+
+> **Crystal Legacy Timeless** is a fork of [Pokémon Crystal Legacy](https://github.com/cRz-Shadows/Pokemon_Crystal_Legacy)
+> that removes all dependence on the cartridge Real-Time Clock (RTC) and ships as an **MBC5**
+> cart, so it runs safely on RTC-less hardware (FPGA cores, flash carts, emulators) without
+> corrupting your save. The clock becomes a frozen value you set manually; time-based events
+> are driven by the day counter and your play time instead of a hardware clock.
+>
+> **→ See [TIMELESS.md](TIMELESS.md) for what this fork changes, why, and how it affects
+> time-based events.**
+>
+> Everything below is the original Crystal Legacy documentation, unchanged.
+
+---
 
 This is a Pokemon Rom Hack made by [TheSmithPlays](https://www.youtube.com/@TheSmithPlays) based on [the Pokémon Crystal Disassembly](https://github.com/pret/pokecrystal) with the intended purpose of fixing Pokemon Crystal into a more polished, balanced and overall engaging Crystal experience. Generation 2 is one of the most beloved sets of games in the franchise. It introduced tons of mechanics to the game that ended up becoming mainstays within the franchise even now. It also had fan favorite Pokemon, a diverse region, deep lore, nonlinearity, and an entire separate region as its postgame which allowed the player to rematch characters from Generation 1. This created an intoxicating and memorable experience that is still remembered by fans today. Unfortunately, it seems that for every good decision Gen 2 saw, there was a mistake made too, and this is why it sees a lot of criticism. Most often, players critique Gen 2 for failing in its representation of its own region’s Pokemon, its inconsistent level curve and a lackluster postgame. Furthermore, terrible learnsets inhibit the vast majority of Pokemon and questionable design choices make diverse party building incredibly difficult. It’s also been criticized for having a poorly written villainous group storyline with no enjoyable payoff. Ultimately, these and many other small features lead to this trio of games feeling incredibly underbaked, much to the dismay of its fans. Feeling as if it could be so much more, TSP (TheSmithPlays) set out to fix this game, and to turn it into the best possible version of itself, while still retaining the iconic Pokemon Crystal feel that fans have come to love. 
 

--- a/TIMELESS.md
+++ b/TIMELESS.md
@@ -91,60 +91,99 @@ The two existing in-game clock screens are now the single source of truth for ti
 
 ---
 
-## How this affects time-based events
+## Time-based events: what to expect
 
 Almost every daily/weekly event in Crystal is keyed off the **day counter** (`wCurDay`) and the
-**weekday** derived from it — not off the raw clock chip. Because the day counter is now under
-your manual control, those events still work; they simply advance **when you advance the day**
+**time of day / weekday** derived from it — not off the raw clock chip. Because the clock is now
+a value **you** set, these events still work; they just advance when **you** move the clock
 instead of in real time.
 
-### Daily events — advance the day yourself
+**The default rule:** unless it's listed in the "always available" table below, every event
+behaves **exactly like vanilla** — it just keys off your manually-set clock. Nothing is removed;
+the daily/weekly cycle is simply driven by you.
 
-When you bump `wCurDay` forward in the clock screen, the daily-reset logic
-(`CheckDailyResetTimer`) wipes all the "already did this today" flags at once, exactly as a real
-midnight rollover would. After advancing a day you'll see, refreshed:
+### Your controls — the clock screen has three levers
 
-- Daily gift / once-per-day NPCs reset
-- Swarms (the roaming/“outbreak” rolls) re-rolled
-- Phone rematch availability refreshed
-- All other `wDailyFlags`-gated events cleared
+Open the clock screen from **New Game**, or any time after by holding **Down + B** on the
+title/continue flow ("reset the clock"). From there you control:
 
-So: **to "wait a day", open the clock screen and move the day forward.**
+| Lever | What it affects |
+|---|---|
+| **Time of day** (Morn / Day / Nite, by hour) | Day/night wild encounters & palettes, and time-locked NPCs (Daisy at 3 PM, Buena at night, bargain shop in the morning) |
+| **Weekday** (Mon–Sun) | All weekday-locked events (see table) |
+| **Day counter** (advance the day) | Triggers the daily reset — refreshes **every** once-per-day event at once |
 
-### Weekday events — set the weekday yourself
+Plus one automatic lever you don't set: **play time** (the odometer on your save file) keeps
+ticking while you play and is what drives **incoming phone calls** (see the last section).
 
-Events tied to a specific day of the week read the weekday computed from `wCurDay`:
+> **"How do I wait a day?"** Open the clock screen and advance the day by one. The game runs its
+> normal midnight reset (`CheckDailyResetTimer`) and every "already did this today" flag clears.
 
-- Department-store sale
-- Weekly siblings (Monday Tuscany, etc.)
-- Trainer-House / weekly-rotation opponents
+---
 
-Set the weekday you want in the clock screen and the matching event becomes active.
+### 1. Always available — daily limit removed (CHANGED)
 
-### Always-available (no day-advance needed)
+These repeatable benefits no longer track a "did it today" flag, so the limit never closes.
+**Any weekday / time-of-day / selection gate they have is kept** — only the once-per-day cap is
+gone. No day-advance needed to reuse them.
 
-To make the hack pleasant on a frozen clock, a few normally once-per-day things were made
-**always available** so you don't have to fiddle with the clock to use them:
+| Event | What it does | Gate still in effect | How to use it |
+|---|---|---|---|
+| **Berry / fruit trees** | Give a held Berry | none | Pick a tree — it's refilled every time, instantly |
+| **Move Tutor** (Goldenrod, Game Corner) | Teaches a special move | none | Talk to him on any visit |
+| **Trainer House battle** | One battle vs. the rotating opponent | which opponent depends on the weekday | Battle as often as you like; set the weekday for a specific opponent |
+| **Haircut brothers** (Goldenrod Underground) | Raises a party Pokémon's happiness | **weekday picks the brother** — older: Tue/Thu/Sat, younger: Sun/Wed/Fri | Get a haircut, then talk again to repeat; set the weekday for older vs. younger |
+| **Buena's Password** (Radio Tower 2F) | +1 Blue Card point (toward prizes, cap 30) | **night only** | **Set the clock to night**, tune the radio for the password, then answer Buena — repeat to grind points |
+| **Goldenrod bargain shop** (Underground) | Sells discounted items | **Monday morning only** | **Set the clock to Monday + morning**, then buy as many times as you want |
+| **Indigo rival rematch** (Pokémon Center) | Battle Silver for XP/money | **appears Mon/Wed only** | **Set the weekday to Mon or Wed**, walk onto the trigger tile; re-enter the map to refight |
 
-| Feature | Original gate | In Timeless |
+### 2. Once-per-day events — refresh by advancing the day (UNTOUCHED)
+
+These keep their normal once-per-day behavior. To use them again, **advance the day** in the
+clock screen.
+
+| Event | What it does | How to trigger / refresh |
 |---|---|---|
-| **Fruit / berry trees** | Refill once per day | **Always refilled** — every tree always has fruit |
-| **Move Tutor** (Goldenrod) | Once per day | **Always available** on each visit |
-| **Trainer House battle** | Once per day | **Repeatable** without advancing the day |
+| **Kurt's Apricorn balls** | Hand Kurt Apricorns; he makes balls "by the next day" | Give Apricorns → **advance the day once** → collect finished balls |
+| **Daily-gift NPCs** | Various "here's something for today" givers | Receive once → **advance the day** to receive again |
+| **Daily swarms** (Dunsparce, Yanma, fishing swarms) | A species floods a route/water for the day | **Advance the day** to re-roll which swarm is active |
+| **Time Capsule** (once-a-day use) | Gen-1 trade link | **Advance the day** to use again |
 
-These work by **not recording** the "did it today" flag, so the gate never closes. (Berries
-additionally drop the daily refill check entirely and refill on every interaction.)
+### 3. Weekday-locked events — set the weekday (UNTOUCHED)
 
-### Deliberately left alone
+These appear/activate only on certain days. **Set the matching weekday** in the clock screen.
 
-- **Daisy's grooming** stays **3 PM-only** — it's a time-of-day check, and you can set the time
-  to 3 PM in the clock screen when you want it.
-- Haircut brothers, Lapras (Friday), Clefairy dance, weekly siblings, swarms, the Indigo rival
-  encounter, and other **weekday/encounter** events stay **manual** — set the appropriate day or
-  time and they trigger normally.
-- **Within-session countdowns that measured real elapsed minutes** (e.g. the Bug Catching
-  Contest's 20-minute timer) no longer tick down on their own, because the clock is frozen. This
-  is an accepted trade-off.
+| Event | Day(s) | Notes |
+|---|---|---|
+| **Dept. Store rooftop sale** (Goldenrod) | its sale day | Set that weekday to shop the sale |
+| **Lapras** (Union Cave B2F) | Friday | Set the weekday to Friday to encounter it |
+| **Bitter-herb merchant** (Underground) | Sat / Sun | Sells bitter healing items those days |
+| **Weekly sibling NPCs** (Tuscany, Frieda, etc.) | each a fixed day | Set the weekday to meet that day's sibling |
+| **Clefairy dance** (Mt. Moon Square) | its scheduled night | Set the matching day/time |
+| **Haircut brother / Trainer-House opponent** | rotate by weekday | (Service itself is repeatable — see table 1 — but *who* is present follows the weekday) |
+
+### 4. Time-of-day-locked events — set the time (UNTOUCHED)
+
+These check the hour. **Set the time of day** in the clock screen.
+
+| Event | Window | How to trigger |
+|---|---|---|
+| **Daisy's grooming** (Pallet, Kanto) | ~3–4 PM | Set the clock to 3 PM, then talk to Daisy |
+| **Buena's Password** | night | Set the clock to night (also see table 1) |
+| **Goldenrod bargain shop** | Monday morning | Set Monday + morning (also see table 1) |
+| **Day/night encounters & palettes** | Morn / Day / Nite | Set the time of day to find time-specific wild Pokémon and color palettes |
+
+### 5. Special cases & trade-offs
+
+- **Shuckie (Mania's loan)** — **not** a daily gift; it's a **one-time loan**, gated by permanent
+  event flags. Its "today" flag only controls the *"come back tomorrow before you can return
+  him"* timing, so it was **left untouched**. **Consequence:** after you receive Shuckie,
+  **advance the day once** before Mania will let you return him — exactly like vanilla.
+- **Kurt's Apricorn balls** — the "ready by the next day" delay was **kept on purpose** (see
+  table 2). Hand over Apricorns, advance the day, collect.
+- **Bug-Catching Contest timer** — the in-contest 20-minute countdown measured *real elapsed
+  minutes*, so with a frozen clock it **no longer ticks down on its own**. The contest still
+  runs; it just won't time you out. This is an accepted trade-off of freezing the clock.
 
 ### Phone calls still happen — driven by play time, not the clock
 
@@ -161,28 +200,13 @@ and you can set the period for time-specific callers.
 
 ---
 
-## Technical change list
+## Building & testing
 
-All changes live in one commit on top of upstream `main`.
+> The exact code changes aren't reproduced here — see the pull request / commit history if you
+> want the assembly-level diff.
 
-| File | Change |
-|---|---|
-| `Makefile` | Cartridge header byte `-m 0x10` (MBC3+TIMER+RAM+BATTERY) → `-m 0x1b` (MBC5+RAM+BATTERY) on all build targets |
-| `home/time.asm` | `GetClock` returns a frozen **zero** clock with **no** hardware access; `LatchClock` and `SetClock` reduced to no-ops (their RTC pokes were the write-corruption path) |
-| `engine/rtc/rtc.asm` | `StartRTC`/`StopRTC` → no-ops; `SaveRTC` keeps only the `sRTCStatusFlags` reset and drops the day-carry poke (which wrote into SRAM after an `RTC_DH` select) |
-| `engine/overworld/time.asm` | Incoming-call delay now measured against play time; new `GetPlaytimeMinutes` helper (`hours*60 + minutes` from `wGameTime*`) |
-| `engine/events/fruit_trees.asm` | `TryResetFruitTrees` drops the once-per-day gate → trees always refill |
-| `maps/GoldenrodCity.asm` | Move Tutor: daily flag no longer set → always available |
-| `maps/TrainerHouseB1F.asm` | Trainer House: daily flag no longer set → repeatable |
-
-What was intentionally **not** touched: `OpenSRAM`/`CloseSRAM` (normal bank 0–3 selection, valid
-and required on MBC5); the clock-setting UI; the save/box layout; the play-time counter.
-
-### Verifying the build
-
-After building with RGBDS **0.5.2** (`make`), confirm cartridge byte `$0147` of the `.gbc`
-reads `0x1B` (MBC5+RAM+BATTERY). In an emulator's cart-info view it should report **MBC5,
-RAM + battery, no RTC**.
+Build with RGBDS **0.5.2** (`make`). Confirm cartridge byte `$0147` of the `.gbc` reads `0x1B`
+(MBC5+RAM+BATTERY); an emulator's cart-info view should report **MBC5, RAM + battery, no RTC**.
 
 ### Recommended on-hardware / emulator checks
 

--- a/TIMELESS.md
+++ b/TIMELESS.md
@@ -1,0 +1,195 @@
+# Crystal Legacy Timeless
+
+**Timeless** is a fork of [Pokémon Crystal Legacy](https://github.com/cRz-Shadows/Pokemon_Crystal_Legacy)
+that removes every dependence on the cartridge **Real-Time Clock (RTC)** and ships the ROM as
+an **MBC5** cart. It is built for hardware that does not faithfully reproduce the MBC3 RTC —
+flash carts, FPGA cores, and emulators where the clock is missing, frozen, or wrong — without
+corrupting your save.
+
+Everything else about Crystal Legacy is unchanged. This document covers only what Timeless
+changes and why. For the base hack's feature list and credits, see [README.md](README.md).
+
+---
+
+## Why this fork exists
+
+Original Pokémon Crystal uses an **MBC3** mapper with a battery-backed **Real-Time Clock**.
+The game tells time by talking to that clock chip. The problem: on hardware **without a real
+RTC**, those clock conversations don't just return garbage — they silently overwrite your
+**saved game**.
+
+### The corruption mechanism (the important part)
+
+On an MBC3 cartridge, the register at `$4000` does double duty:
+
+- Write `$00`–`$03` → select an **SRAM bank** (where your boxes/save live).
+- Write `$08`–`$0C` → select an **RTC register** (seconds, minutes, hours, day-low, day-high),
+  which you then read/write through `$A000`.
+
+The game reads the clock by writing one of those `$08`–`$0C` selectors and then touching
+`$A000`. **On hardware with no RTC, the mapper has no `$08`–`$0C` mode** — those values are
+just treated as ordinary (out-of-range) SRAM bank numbers. So a "read the clock" sequence
+becomes a "read/write some SRAM bank" sequence pointed at `$A000`.
+
+The day-low selector is `RTC_DL = $0B`. With no RTC that selects **SRAM bank 3**, and on this
+ROM's save layout (`sram.link`) bank 3 begins exactly at **Box 8**. So:
+
+- **Writing the clock** (`SetClock`, and the day-carry poke inside `SaveRTC`) scribbles time
+  bytes directly over **Box 8** and neighbouring save data → corrupted Pokémon storage.
+- **Reading the clock** (`GetClock`) reads box bytes back *as if they were the current time* →
+  the in-game time jumps around at random whenever anything reads the clock: collecting
+  berries, entering battles, changing maps, opening the Pokégear.
+- Worse: the garbage day count routinely looks like ">140 days passed", which makes the time
+  fix-up code (`FixDays`) call `SetClock` to "correct" it → **more writes, more corruption**.
+
+This is the bug behind "Box 8 keeps getting wiped" and "the clock keeps changing on its own".
+
+### Why MBC5
+
+If the game never touches the RTC, it never needs the MBC3-specific clock hardware at all. MBC5
+is a strict superset of MBC3's *banking* behaviour (same `$00`–`$03` SRAM bank selects, same
+`$2000` ROM banking for this ROM's size) but **has no RTC** and no `$08`–`$0C` selector mode.
+Shipping as MBC5 means:
+
+- The hardware target is simpler and far more commonly/faithfully implemented (the FPGA MBC5
+  core this was built for is verified solid; its MBC3+RTC core is not).
+- Even if some stray RTC-style write slipped through, MBC5 has nowhere for it to land as a
+  clock — it can't re-enable the corruption path.
+
+**The save format does not change.** Box layout, SRAM size (32 KB), and the battery are all
+identical. Existing `.sav` files work as-is; no byte patching needed.
+
+---
+
+## What replaces the clock: a frozen software clock
+
+With the RTC gone, time is now a **purely software value that the player sets** and that
+**never advances on its own**.
+
+The game already stores the time the player picks during New Game / clock reset as a set of
+"start" offsets (`wStartDay`, `wStartHour`, `wStartMinute`, …). Normally the *current* time is
+computed as `RTC_now − start_offset`. Timeless makes the RTC read return **all zeros**, so:
+
+```
+current time = 0 − start_offset  →  resolves to exactly the offsets you set
+```
+
+The time-of-day, the day-of-week, and the day counter are now **whatever you last set in the
+clock UI, frozen there until you change it again**.
+
+- Set it to night and grind for an hour → it stays night. Day/night palettes are stable.
+- The day counter (`wCurDay`) only moves when **you** move it in the clock-setting screen.
+
+### Setting / changing the clock
+
+The two existing in-game clock screens are now the single source of truth for time:
+
+- **New Game** — the normal "set the time" prompt at the start of the game.
+- **Clock reset** — hold **Down + B** on the title/continue flow to re-open the clock screen
+  (the vanilla Crystal "reset the clock" feature). Use this any time you want to change the
+  time of day, the weekday, or bump the day forward.
+
+---
+
+## How this affects time-based events
+
+Almost every daily/weekly event in Crystal is keyed off the **day counter** (`wCurDay`) and the
+**weekday** derived from it — not off the raw clock chip. Because the day counter is now under
+your manual control, those events still work; they simply advance **when you advance the day**
+instead of in real time.
+
+### Daily events — advance the day yourself
+
+When you bump `wCurDay` forward in the clock screen, the daily-reset logic
+(`CheckDailyResetTimer`) wipes all the "already did this today" flags at once, exactly as a real
+midnight rollover would. After advancing a day you'll see, refreshed:
+
+- Daily gift / once-per-day NPCs reset
+- Swarms (the roaming/“outbreak” rolls) re-rolled
+- Phone rematch availability refreshed
+- All other `wDailyFlags`-gated events cleared
+
+So: **to "wait a day", open the clock screen and move the day forward.**
+
+### Weekday events — set the weekday yourself
+
+Events tied to a specific day of the week read the weekday computed from `wCurDay`:
+
+- Department-store sale
+- Weekly siblings (Monday Tuscany, etc.)
+- Trainer-House / weekly-rotation opponents
+
+Set the weekday you want in the clock screen and the matching event becomes active.
+
+### Always-available (no day-advance needed)
+
+To make the hack pleasant on a frozen clock, a few normally once-per-day things were made
+**always available** so you don't have to fiddle with the clock to use them:
+
+| Feature | Original gate | In Timeless |
+|---|---|---|
+| **Fruit / berry trees** | Refill once per day | **Always refilled** — every tree always has fruit |
+| **Move Tutor** (Goldenrod) | Once per day | **Always available** on each visit |
+| **Trainer House battle** | Once per day | **Repeatable** without advancing the day |
+
+These work by **not recording** the "did it today" flag, so the gate never closes. (Berries
+additionally drop the daily refill check entirely and refill on every interaction.)
+
+### Deliberately left alone
+
+- **Daisy's grooming** stays **3 PM-only** — it's a time-of-day check, and you can set the time
+  to 3 PM in the clock screen when you want it.
+- Haircut brothers, Lapras (Friday), Clefairy dance, weekly siblings, swarms, the Indigo rival
+  encounter, and other **weekday/encounter** events stay **manual** — set the appropriate day or
+  time and they trigger normally.
+- **Within-session countdowns that measured real elapsed minutes** (e.g. the Bug Catching
+  Contest's 20-minute timer) no longer tick down on their own, because the clock is frozen. This
+  is an accepted trade-off.
+
+### Phone calls still happen — driven by play time, not the clock
+
+Incoming phone calls (rematch notices, daily-gift reminders, Buena's password reminders) are
+normally scheduled by *real elapsed clock minutes*. With a frozen clock that interval would
+**never elapse and no call would ever fire.**
+
+Timeless re-points the incoming-call countdown at the **play-time counter** (`wGameTime*`) — the
+odometer that ticks up from VBlank every frame the game runs (the value you see as your save
+file's play time). It is independent of the RTC and always moves forward while you play, so
+spontaneous calls still fire after a few minutes of play, just as before. *Who* is eligible to
+call at a given time-of-day still reads the (frozen) clock — "anytime" contacts always qualify,
+and you can set the period for time-specific callers.
+
+---
+
+## Technical change list
+
+All changes live in one commit on top of upstream `main`.
+
+| File | Change |
+|---|---|
+| `Makefile` | Cartridge header byte `-m 0x10` (MBC3+TIMER+RAM+BATTERY) → `-m 0x1b` (MBC5+RAM+BATTERY) on all build targets |
+| `home/time.asm` | `GetClock` returns a frozen **zero** clock with **no** hardware access; `LatchClock` and `SetClock` reduced to no-ops (their RTC pokes were the write-corruption path) |
+| `engine/rtc/rtc.asm` | `StartRTC`/`StopRTC` → no-ops; `SaveRTC` keeps only the `sRTCStatusFlags` reset and drops the day-carry poke (which wrote into SRAM after an `RTC_DH` select) |
+| `engine/overworld/time.asm` | Incoming-call delay now measured against play time; new `GetPlaytimeMinutes` helper (`hours*60 + minutes` from `wGameTime*`) |
+| `engine/events/fruit_trees.asm` | `TryResetFruitTrees` drops the once-per-day gate → trees always refill |
+| `maps/GoldenrodCity.asm` | Move Tutor: daily flag no longer set → always available |
+| `maps/TrainerHouseB1F.asm` | Trainer House: daily flag no longer set → repeatable |
+
+What was intentionally **not** touched: `OpenSRAM`/`CloseSRAM` (normal bank 0–3 selection, valid
+and required on MBC5); the clock-setting UI; the save/box layout; the play-time counter.
+
+### Verifying the build
+
+After building with RGBDS **0.5.2** (`make`), confirm cartridge byte `$0147` of the `.gbc`
+reads `0x1B` (MBC5+RAM+BATTERY). In an emulator's cart-info view it should report **MBC5,
+RAM + battery, no RTC**.
+
+### Recommended on-hardware / emulator checks
+
+1. New game → set the time → deposit a Pokémon in **Box 8**.
+2. Pick berries, fight several battles, change maps, open the Pokégear, then **save & reload**.
+3. Confirm **Box 8 is intact** and the **clock did not jump**. (This is the core fix.)
+4. Set night, walk around a while → still night (frozen clock).
+5. Open the clock screen, advance a day → confirm daily events refreshed; set a weekday →
+   confirm a weekday event appears.
+6. Play continuously a few minutes → confirm an incoming phone call still fires.

--- a/TIMELESS.md
+++ b/TIMELESS.md
@@ -104,8 +104,9 @@ the daily/weekly cycle is simply driven by you.
 
 ### Your controls — the clock screen has three levers
 
-Open the clock screen from **New Game**, or any time after by holding **Down + B** on the
-title/continue flow ("reset the clock"). From there you control:
+Open the clock screen from **New Game**, or any time after by holding **Down + B** at the
+**title screen** (the one showing Suicune leaping over the water, before the "Continue / New
+Game" menu) — this is the vanilla "reset the clock" feature. From there you control:
 
 | Lever | What it affects |
 |---|---|

--- a/engine/events/fruit_trees.asm
+++ b/engine/events/fruit_trees.asm
@@ -41,9 +41,8 @@ GetCurTreeFruit:
 	ret
 
 TryResetFruitTrees:
-	ld hl, wDailyFlags1
-	bit DAILYFLAGS1_ALL_FRUIT_TREES_F, [hl]
-	ret nz
+; Always refill every fruit tree: drop the once-per-day gate so berries are
+; available without advancing the (manually set) clock.
 	jp ResetFruitTrees
 
 CheckFruitTree:

--- a/engine/items/mart.asm
+++ b/engine/items/mart.asm
@@ -54,8 +54,10 @@ BargainShop:
 	ld a, [hli]
 	or [hl]
 	jr z, .skip_set
-	ld hl, wDailyFlags1
-	set DAILYFLAGS1_GOLDENROD_UNDERGROUND_BARGAIN_F, [hl]
+	; No RTC: don't record the once-per-day "merchant closed" flag, so the bargain
+	; shop can be used repeatedly (it's still Monday-morning-only via the map script).
+	; ld hl, wDailyFlags1
+	; set DAILYFLAGS1_GOLDENROD_UNDERGROUND_BARGAIN_F, [hl]
 
 .skip_set
 	ld hl, BargainShopComeAgainText

--- a/engine/overworld/time.asm
+++ b/engine/overworld/time.asm
@@ -81,19 +81,84 @@ CheckDayDependentEventHL:
 	ret
 
 RestartReceiveCallDelay:
+; The in-game clock is frozen (no RTC), so the receive-call countdown is driven
+; by the play-time counter (wGameTime*), which keeps ticking while playing.
+; Snapshot the current play-time (in minutes) as the baseline.
 	ld hl, wReceiveCallDelay_MinsRemaining
 	ld [hl], a
-	call UpdateTime
-	ld hl, wReceiveCallDelay_StartTime
-	call CopyDayHourMinToHL
+	call GetPlaytimeMinutes ; hl = play time in minutes
+	ld a, l
+	ld [wReceiveCallDelay_StartTime], a
+	ld a, h
+	ld [wReceiveCallDelay_StartTime + 1], a
 	ret
 
 CheckReceiveCallDelay:
-	ld hl, wReceiveCallDelay_StartTime
-	call CalcMinsHoursDaysSince
-	call GetMinutesSinceIfLessThan60
+; Subtract the play-time minutes elapsed since the last check from the countdown.
+; Carry set (call allowed) once it reaches 0. Mirrors the original incremental
+; behaviour, but measured in play time instead of the frozen clock.
+	call GetPlaytimeMinutes ; hl = play time now (minutes)
+	ld a, [wReceiveCallDelay_StartTime]
+	ld e, a
+	ld a, [wReceiveCallDelay_StartTime + 1]
+	ld d, a
+; advance the baseline to now
+	ld a, l
+	ld [wReceiveCallDelay_StartTime], a
+	ld a, h
+	ld [wReceiveCallDelay_StartTime + 1], a
+; bc = now - baseline (minutes elapsed since last check)
+	ld a, l
+	sub e
+	ld c, a
+	ld a, h
+	sbc d
+	ld b, a
+; cap elapsed to 0-59; 60+ (or high byte set) -> -1 so the countdown fires now
+	and a ; a still holds b (elapsed high byte)
+	jr nz, .elapsed_capped
+	ld a, c
+	cp 60
+	jr c, .apply
+.elapsed_capped
+	ld a, -1
+.apply
 	ld hl, wReceiveCallDelay_MinsRemaining
 	call UpdateTimeRemaining
+	ret
+
+GetPlaytimeMinutes:
+; Return hl = total play time in minutes = wGameTimeHours * 60 + wGameTimeMinutes.
+; wGameTimeHours is a big-endian 16-bit value capped at 999, so the result
+; (<= 59999) always fits in 16 bits.
+	ld a, [wGameTimeHours]
+	ld h, a
+	ld a, [wGameTimeHours + 1]
+	ld l, a
+; hl = hours * 4, save into de
+	add hl, hl
+	add hl, hl
+	ld d, h
+	ld e, l
+; hl = hours * 64
+	add hl, hl
+	add hl, hl
+	add hl, hl
+	add hl, hl
+; hl = hours * 64 - hours * 4 = hours * 60
+	ld a, l
+	sub e
+	ld l, a
+	ld a, h
+	sbc d
+	ld h, a
+; hl += minutes
+	ld a, [wGameTimeMinutes]
+	add l
+	ld l, a
+	ld a, 0
+	adc h
+	ld h, a
 	ret
 
 RestartDailyResetTimer:

--- a/engine/rtc/rtc.asm
+++ b/engine/rtc/rtc.asm
@@ -1,25 +1,10 @@
 StopRTC: ; unreferenced
-	ld a, SRAM_ENABLE
-	ld [MBC3SRamEnable], a
-	call LatchClock
-	ld a, RTC_DH
-	ld [MBC3SRamBank], a
-	ld a, [MBC3RTC]
-	set 6, a ; halt
-	ld [MBC3RTC], a
-	call CloseSRAM
+; No real-time clock on this hardware; nothing to halt.
 	ret
 
 StartRTC:
-	ld a, SRAM_ENABLE
-	ld [MBC3SRamEnable], a
-	call LatchClock
-	ld a, RTC_DH
-	ld [MBC3SRamBank], a
-	ld a, [MBC3RTC]
-	res 6, a ; halt
-	ld [MBC3RTC], a
-	call CloseSRAM
+; No real-time clock on this hardware; nothing to start. (Poking the RTC_DH
+; selector here would select an SRAM bank and write into save data.)
 	ret
 
 GetTimeOfDay::
@@ -74,15 +59,11 @@ StageRTCTimeForSave:
 	ret
 
 SaveRTC:
-	ld a, SRAM_ENABLE
-	ld [MBC3SRamEnable], a
-	call LatchClock
-	ld hl, MBC3RTC
-	ld a, RTC_DH
-	ld [MBC3SRamBank], a
-	res 7, [hl]
+; Originally cleared the RTC day-carry bit then reset sRTCStatusFlags. With no
+; real-time clock, only the flag reset remains; the day-carry poke is dropped
+; (it wrote to $a000 after an RTC_DH select -> SRAM bank -> save corruption).
 	ld a, BANK(sRTCStatusFlags)
-	ld [MBC3SRamBank], a
+	call OpenSRAM
 	xor a
 	ld [sRTCStatusFlags], a
 	call CloseSRAM

--- a/home/time.asm
+++ b/home/time.asm
@@ -12,11 +12,8 @@ Timer:: ; unreferenced
 	reti
 
 LatchClock::
-; latch clock counter data
-	ld a, 0
-	ld [MBC3LatchClock], a
-	ld a, 1
-	ld [MBC3LatchClock], a
+; No real-time clock on this hardware (RTC-less MBC3 / MBC5).
+; Latching would poke the MBC3 clock register; do nothing.
 	ret
 
 UpdateTime::
@@ -28,42 +25,18 @@ UpdateTime::
 
 GetClock::
 ; store clock data in hRTCDayHi-hRTCSeconds
-
-; enable clock r/w
-	ld a, SRAM_ENABLE
-	ld [MBC3SRamEnable], a
-
-; clock data is 'backwards' in hram
-
-	call LatchClock
-	ld hl, MBC3SRamBank
-	ld de, MBC3RTC
-
-	ld [hl], RTC_S
-	ld a, [de]
-	maskbits 60
+;
+; This hardware has no real-time clock. Reading the MBC3 clock registers here
+; would actually select an SRAM bank ($08-$0c -> bank 0-4) and read box data as
+; if it were the time (corrupting the time and, on write, Box 8). Instead return
+; a frozen zero clock: the displayed time becomes exactly the wStart* offsets set
+; by the player in the clock-setting UI (see FixTime), and never drifts on its own.
+	xor a
 	ldh [hRTCSeconds], a
-
-	ld [hl], RTC_M
-	ld a, [de]
-	maskbits 60
 	ldh [hRTCMinutes], a
-
-	ld [hl], RTC_H
-	ld a, [de]
-	maskbits 24
 	ldh [hRTCHours], a
-
-	ld [hl], RTC_DL
-	ld a, [de]
 	ldh [hRTCDayLo], a
-
-	ld [hl], RTC_DH
-	ld a, [de]
 	ldh [hRTCDayHi], a
-
-; unlatch clock / disable clock r/w
-	call CloseSRAM
 	ret
 
 FixDays::
@@ -210,50 +183,10 @@ ClearClock::
 	ret
 
 SetClock::
-; set clock data from hram
-
-; enable clock r/w
-	ld a, SRAM_ENABLE
-	ld [MBC3SRamEnable], a
-
-; set clock data
-; stored 'backwards' in hram
-
-	call LatchClock
-	ld hl, MBC3SRamBank
-	ld de, MBC3RTC
-
-; seems to be a halt check that got partially commented out
-; this block is totally pointless
-	ld [hl], RTC_DH
-	ld a, [de]
-	bit 6, a ; halt
-	ld [de], a
-
-; seconds
-	ld [hl], RTC_S
-	ldh a, [hRTCSeconds]
-	ld [de], a
-; minutes
-	ld [hl], RTC_M
-	ldh a, [hRTCMinutes]
-	ld [de], a
-; hours
-	ld [hl], RTC_H
-	ldh a, [hRTCHours]
-	ld [de], a
-; day lo
-	ld [hl], RTC_DL
-	ldh a, [hRTCDayLo]
-	ld [de], a
-; day hi
-	ld [hl], RTC_DH
-	ldh a, [hRTCDayHi]
-	res 6, a ; make sure timer is active
-	ld [de], a
-
-; cleanup
-	call CloseSRAM ; unlatch clock, disable clock r/w
+; No real-time clock on this hardware. Writing the clock here would select an
+; SRAM bank via the RTC register selectors ($08-$0c) and clobber save data
+; (RTC_DL=$0b -> SRAM bank 3 -> start of Box 8). Do nothing; the software clock
+; lives entirely in the wStart* offsets set through the clock UI.
 	ret
 
 ClearRTCStatus:: ; unreferenced

--- a/maps/GoldenrodCity.asm
+++ b/maps/GoldenrodCity.asm
@@ -138,7 +138,9 @@ MoveTutorScript:
 	playsound SFX_ENTER_DOOR
 	disappear GOLDENRODCITY_MOVETUTOR
 	clearevent EVENT_GOLDENROD_GAME_CORNER_MOVE_TUTOR
-	setflag ENGINE_DAILY_MOVE_TUTOR
+	; No RTC: don't record the once-per-day flag, so the Move Tutor is always
+	; available again on the next visit without advancing the (manual) clock.
+	; setflag ENGINE_DAILY_MOVE_TUTOR
 	waitsfx
 	end
 

--- a/maps/GoldenrodUnderground.asm
+++ b/maps/GoldenrodUnderground.asm
@@ -204,7 +204,9 @@ OlderHaircutBrotherScript:
 	special OlderHaircutBrother
 	ifequal $0, .Refused
 	ifequal $1, .Refused
-	setflag ENGINE_GOLDENROD_UNDERGROUND_GOT_HAIRCUT
+	; No RTC: don't record the once-per-day flag, so haircuts can be repeated
+	; (the weekday still picks which brother is available).
+	; setflag ENGINE_GOLDENROD_UNDERGROUND_GOT_HAIRCUT
 	ifequal $2, .two
 	ifequal $3, .three
 	sjump .else
@@ -287,7 +289,9 @@ YoungerHaircutBrotherScript:
 	special YoungerHaircutBrother
 	ifequal $0, .Refused
 	ifequal $1, .Refused
-	setflag ENGINE_GOLDENROD_UNDERGROUND_GOT_HAIRCUT
+	; No RTC: don't record the once-per-day flag, so haircuts can be repeated
+	; (the weekday still picks which brother is available).
+	; setflag ENGINE_GOLDENROD_UNDERGROUND_GOT_HAIRCUT
 	ifequal $2, .two
 	ifequal $3, .three
 	sjump .else

--- a/maps/IndigoPlateauPokecenter1F.asm
+++ b/maps/IndigoPlateauPokecenter1F.asm
@@ -142,7 +142,9 @@ PlateauRivalPostBattle:
 	disappear INDIGOPLATEAUPOKECENTER1F_SILVER
 	setscene SCENE_DEFAULT
 	playmapmusic
-	setflag ENGINE_INDIGO_PLATEAU_RIVAL_FIGHT
+	; No RTC: don't record the once-per-day flag, so the rival rematch can be
+	; repeated by re-entering the map (the Mon/Wed weekday gate above still applies).
+	; setflag ENGINE_INDIGO_PLATEAU_RIVAL_FIGHT
 PlateauRivalScriptDone:
 	end
 

--- a/maps/RadioTower2F.asm
+++ b/maps/RadioTower2F.asm
@@ -146,7 +146,9 @@ Buena:
 	writevar VAR_BLUECARDBALANCE
 	waitsfx
 	playsound SFX_TRANSACTION
-	setflag ENGINE_BUENAS_PASSWORD_2
+	; No RTC: don't record the once-per-day "played today" flag, so the password
+	; quiz stays repeatable (it's still night-only via the VAR_HOUR check above).
+	; setflag ENGINE_BUENAS_PASSWORD_2
 	pause 20
 	turnobject RADIOTOWER2F_BUENA, RIGHT
 	opentext
@@ -201,7 +203,8 @@ Buena:
 	end
 
 .WrongAnswer:
-	setflag ENGINE_BUENAS_PASSWORD_2
+	; No RTC: don't close the quiz for the day on a wrong answer either.
+	; setflag ENGINE_BUENAS_PASSWORD_2
 	opentext
 	writetext RadioTower2FBuenaDidYouForgetText
 	waitbutton

--- a/maps/TrainerHouseB1F.asm
+++ b/maps/TrainerHouseB1F.asm
@@ -66,7 +66,9 @@ TrainerHouseReceptionistScript:
 	writetext TrainerHouseB1FAskWantToBattleText
 	yesorno
 	iffalse .Declined
-	setflag ENGINE_FOUGHT_IN_TRAINER_HALL_TODAY
+	; No RTC: don't record the once-per-day flag, so Trainer House battles can be
+	; repeated without advancing the (manual) clock.
+	; setflag ENGINE_FOUGHT_IN_TRAINER_HALL_TODAY
 	writetext TrainerHouseB1FGoRightInText
 	waitbutton
 	closetext


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/build.yml` that builds rgbds 0.5.2 from source on Ubuntu and runs `make` + `make crystal11` to verify both ROM variants assemble cleanly.
- Triggers on pushes to `main` and on every PR.
- Skips `make compare` — the Timeless mods (RTC removal, freebies changes) intentionally diverge the ROM from the original `roms.sha1` manifest, so gating on a successful build is the meaningful check.

## Motivation
Foundation for enabling required-status-check branch protection on `main`. Once this PR merges and the `build` check is registered on the default branch, we can wire it up as a required status check.

## Test plan
- [ ] Workflow run on this PR succeeds (builds `pokecrystal.gbc` and `pokecrystal11.gbc`).
- [ ] After merge, the `build` check appears as available to require in branch protection settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)